### PR TITLE
Add fix for Firebase initialisation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -306,6 +306,17 @@
         "@babel/helper-plugin-utils": "^7.8.3"
       }
     },
+    "@babel/plugin-proposal-decorators": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-decorators/-/plugin-proposal-decorators-7.8.3.tgz",
+      "integrity": "sha512-e3RvdvS4qPJVTe288DlXjwKflpfy1hr0j5dz5WpIYYeP7vQZg2WfAEIp8k5/Lwis/m5REXEteIz6rrcDtXXG7w==",
+      "dev": true,
+      "requires": {
+        "@babel/helper-create-class-features-plugin": "^7.8.3",
+        "@babel/helper-plugin-utils": "^7.8.3",
+        "@babel/plugin-syntax-decorators": "^7.8.3"
+      }
+    },
     "@babel/plugin-proposal-export-default-from": {
       "version": "7.8.3",
       "resolved": "https://registry.npmjs.org/@babel/plugin-proposal-export-default-from/-/plugin-proposal-export-default-from-7.8.3.tgz",
@@ -355,6 +366,15 @@
       "version": "7.8.3",
       "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-class-properties/-/plugin-syntax-class-properties-7.8.3.tgz",
       "integrity": "sha512-UcAyQWg2bAN647Q+O811tG9MrJ38Z10jjhQdKNAL8fsyPzE3cCN/uT+f55cFVY4aGO4jqJAvmqsuY3GQDwAoXg==",
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.8.3"
+      }
+    },
+    "@babel/plugin-syntax-decorators": {
+      "version": "7.8.3",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-decorators/-/plugin-syntax-decorators-7.8.3.tgz",
+      "integrity": "sha512-8Hg4dNNT9/LcA1zQlfwuKR8BUc/if7Q7NkTam9sGTcJphLwpf2g4S42uhspQrIrR+dpzE0dtTqBVFoHl8GtnnQ==",
+      "dev": true,
       "requires": {
         "@babel/helper-plugin-utils": "^7.8.3"
       }
@@ -6234,6 +6254,16 @@
           "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
         }
       }
+    },
+    "mobx": {
+      "version": "5.15.4",
+      "resolved": "https://registry.npmjs.org/mobx/-/mobx-5.15.4.tgz",
+      "integrity": "sha512-xRFJxSU2Im3nrGCdjSuOTFmxVDGeqOHL+TyADCGbT0k4HHqGmx5u2yaHNryvoORpI4DfbzjJ5jPmuv+d7sioFw=="
+    },
+    "mobx-react-lite": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/mobx-react-lite/-/mobx-react-lite-1.5.2.tgz",
+      "integrity": "sha512-PyZmARqqWtpuQaAoHF5pKX7h6TKNLwq6vtovm4zZvG6sEbMRHHSqioGXSeQbpRmG8Kw8uln3q/W1yMO5IfL5Sg=="
     },
     "morgan": {
       "version": "1.9.1",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -7,12 +7,13 @@ import { useStores } from './hooks';
 
 import Chat from './components/Chat';
 import Button from './components/common/Button';
+import { FirebaseAuthTypes } from '@react-native-firebase/auth';
 
 const App = observer(() => {
   const { userStore } = useStores()
   const [initializing, setInitializing] = useState(true);
 
-  function onAuthStateChanged(user: any): void {
+  function onAuthStateChanged(user: FirebaseAuthTypes.User | null): void {
     userStore.setCurrentUser(user);
     if (initializing) setInitializing(false);
   }

--- a/src/services/Firebase.tsx
+++ b/src/services/Firebase.tsx
@@ -22,7 +22,11 @@ class FireBaseService {
     msgRef: FirebaseFirestoreTypes.CollectionReference;
 
     constructor() {
-        this.app = firebase.initializeApp(config);
+        if (firebase.apps.length === 0) {
+            this.app = firebase.initializeApp(config);
+        } else {
+            this.app = firebase.app();
+        }
         this.auth = auth();
         this.db = firestore();
         this.msgRef = this.db.collection(COLLECTIONS.MESSAGES);

--- a/src/stores/UserStore.tsx
+++ b/src/stores/UserStore.tsx
@@ -6,14 +6,20 @@ import { FirebaseAuthTypes } from '@react-native-firebase/auth';
 export default class UserStore {
     /* User State */
     @observable
-    uid: string | undefined;
+    uid: string | null = null;
     @observable
     email: string | null = null;
     @observable
     name: string | null = null;
 
     @action
-    setCurrentUser(user: FirebaseAuthTypes.User) {
+    setCurrentUser(user: FirebaseAuthTypes.User | null): void {
+        if (user === null) {
+            this.uid = null;
+            this.email = null;
+            this.name = null;
+            return;
+        }
         this.uid = user.uid;
         this.email = user.email;
         this.name = user.displayName;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -43,7 +43,7 @@
     // "typeRoots": [],                       /* List of folders to include type definitions from. */
     // "types": [],                           /* Type declaration files to be included in compilation. */
     "allowSyntheticDefaultImports": true,     /* Allow default imports from modules with no default export. This does not affect code emit, just typechecking. */
-    "esModuleInterop": true                   /* Enables emit interoperability between CommonJS and ES Modules via creation of namespace objects for all imports. Implies 'allowSyntheticDefaultImports'. */
+    "esModuleInterop": true,                   /* Enables emit interoperability between CommonJS and ES Modules via creation of namespace objects for all imports. Implies 'allowSyntheticDefaultImports'. */
     // "preserveSymlinks": true,              /* Do not resolve the real path of symlinks. */
 
     /* Source Map Options */


### PR DESCRIPTION
This PR adds a check for any pre-existing Firebase instances before initialising a new one. If one already exists, the Firebase service will retrieve the existing one instead. This PR also ensures UserStore is updated with null values when a null user is passed in (i.e. when we log out). 

**Test plan:**
1. Clear app's data 
![image](https://user-images.githubusercontent.com/7235102/74822521-181a6880-52ba-11ea-97a0-40830c1d921b.png)

2. Start app and check that app starts up without error
![image](https://user-images.githubusercontent.com/7235102/74823778-223d6680-52bc-11ea-898a-25b64a49dd56.png)

3. Log in and check no error occurs 
![image](https://user-images.githubusercontent.com/7235102/74823814-2ff2ec00-52bc-11ea-9e36-1208204c81f6.png)

4. Log out and check no error occurs 
![image](https://user-images.githubusercontent.com/7235102/74823826-37b29080-52bc-11ea-8b2b-f7503bf40dcb.png)




